### PR TITLE
Fedora 38 should not show EOL warning until 2024

### DIFF
--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
@@ -54,7 +54,7 @@
   },
   {
     "pattern": "Fedora.* 38",
-    "endOfLife": "2023-05-18"
+    "endOfLife": "2024-05-18"
   },
   {
     "pattern": "Oracle Linux.* 7",


### PR DESCRIPTION
Sorry, please ignore, meant to file against jenkinsci/jenkins.